### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const Lafayette = require('lafayette');
 
 const options = { whitelist: ['image/png'] };
 
-Fs.createWriteStream('file.png').end(new Buffer('89504e47', 'hex'));
+Fs.createWriteStream('file.png').end(Buffer.from('89504e47', 'hex'));
 
 const png = {
     filename: 'file.png',
@@ -91,7 +91,7 @@ const Lafayette = require('lafayette');
 
 const options = { whitelist: ['image/png'] };
 
-Fs.createWriteStream('file.gif').end(new Buffer('47494638', 'hex'));
+Fs.createWriteStream('file.gif').end(Buffer.from('47494638', 'hex'));
 
 const gif = {
     filename: 'file.gif',

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   },
   "homepage": "https://github.com/ruiquelhas/lafayette#readme",
   "devDependencies": {
-    "code": "3.x.x",
+    "code": "4.x.x",
     "coveralls": "2.x.x",
-    "hapi": "13.x.x",
-    "lab": "10.x.x",
-    "multi-part": "1.x.x"
+    "hapi": "15.x.x",
+    "lab": "11.x.x",
+    "multi-part": "2.x.x"
   },
   "dependencies": {
     "hoek": "4.x.x",
@@ -40,6 +40,6 @@
     "thurston": "2.x.x"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.5.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -58,7 +58,7 @@ lab.experiment('Lafayette', () => {
         form.append('file', Fs.createReadStream(invalid));
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.get(), url: '/' }, (response) => {
+        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(400);
             Code.expect(response.result).to.include(['message', 'validation']);
@@ -81,7 +81,7 @@ lab.experiment('Lafayette', () => {
         form.append('file2', Fs.createReadStream(png));
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.get(), url: '/' }, (response) => {
+        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
             done();

--- a/test/index.js
+++ b/test/index.js
@@ -52,7 +52,7 @@ lab.experiment('Lafayette', () => {
 
         const invalid = Path.join(Os.tmpdir(), 'invalid');
 
-        Fs.createWriteStream(invalid).end(new Buffer('ffffffff', 'hex'));
+        Fs.createWriteStream(invalid).end(Buffer.from('ffffffff', 'hex'));
 
         const form = new Form();
         form.append('file', Fs.createReadStream(invalid));
@@ -74,7 +74,7 @@ lab.experiment('Lafayette', () => {
 
         const png = Path.join(Os.tmpdir(), 'foo.png');
 
-        Fs.createWriteStream(png).end(new Buffer('89504e47', 'hex'));
+        Fs.createWriteStream(png).end(Buffer.from('89504e47', 'hex'));
 
         const form = new Form();
         form.append('file1', Fs.createReadStream(png));


### PR DESCRIPTION
Update 3rd-party modules and supported node engine. Switch to the new `Buffer` API available since `v4.5.0`.
